### PR TITLE
fix: removes unused method from RNBrptouchPrinterPackage

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNBrptouchprinterPackage.java
+++ b/android/src/main/java/com/reactlibrary/RNBrptouchprinterPackage.java
@@ -17,11 +17,6 @@ public class RNBrptouchprinterPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }


### PR DESCRIPTION
this method is not used with newer versions of react-native